### PR TITLE
feat: add getUnifiedNetwork to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 scratch/
 cli/
 .DS_Store
+tools/osm/download

--- a/src/distance/haversine.ts
+++ b/src/distance/haversine.ts
@@ -23,5 +23,6 @@ export const haversineDistance = (pointOne: Position, pointTwo: Position): numbe
     const distance = radius * c;
 
 
+    // Convert distance from meters to kilometers
     return distance / 1000;
 }

--- a/src/graph/graph.spec.ts
+++ b/src/graph/graph.spec.ts
@@ -157,7 +157,6 @@ describe("LineStringGraph", () => {
         expect(graphAfterThirdPrune.features.length).toBeLessThan(graphAfterSecondPrune.features.length);
     });
 
-
     describe('getNetworkInBoundingBox', () => {
         it('filters network LineStrings based on bounding box', () => {
             const insideLine = createLineStringFeature([[1, 1], [2, 2]]);
@@ -201,6 +200,38 @@ describe("LineStringGraph", () => {
             // Modifying filtered result shouldn't affect original
             filteredNetwork.features.pop();
             expect(graph.getNetwork().features).toHaveLength(1);
+        });
+    });
+
+    describe('getUnifiedNetwork', () => {
+        it('returns the unified network', () => {
+            const insideLine = createLineStringFeature([[1, 1], [2, 2]]);
+            const outsideLine = createLineStringFeature([[1.000001, 1.000001], [20, 20]]);
+
+            const network = createFeatureCollection([insideLine, outsideLine]);
+            const graph = new LineStringGraph(network);
+
+            const filteredNetwork = graph.getUnifiedNetwork(0.5);
+
+            expect(filteredNetwork.features).toHaveLength(2);
+            expect(filteredNetwork.features).toEqual([
+                {
+                    "geometry": {
+                        "coordinates": [[1, 1], [2, 2]],
+                        "type": "LineString"
+                    },
+                    "properties": {},
+                    "type": "Feature"
+                },
+                {
+                    "geometry": {
+                        "coordinates": [[1, 1], [20, 20]],
+                        "type": "LineString"
+                    },
+                    "properties": {},
+                    "type": "Feature"
+                }
+            ]);
         });
     });
 

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -6,6 +6,7 @@ import { routeLength } from "../test-utils/utils";
 import { removeDuplicateAndSubsectionLines } from "./methods/duplicates";
 import { getLeafEdges } from "./methods/leaf";
 import { getNetworkInBoundingBox, BoundingBox } from "./methods/bounding-box";
+import { unifyCloseCoordinates } from "./methods/unify";
 
 /**
  * Represents a graph constructed from a GeoJSON FeatureCollection of LineString features.
@@ -198,5 +199,14 @@ export class LineStringGraph {
 
         }
         return getLeafEdges(this.network).nonLeafEdges;
+    }
+
+    /**
+     * Returns the network where all nodes that are with n meters of each other are unified. 
+     * The function will avoid unifying coordinates in the same linestring.
+     * @param toleranceMeters the tolerance for unifying nodes in meters. 
+     */
+    getUnifiedNetwork(toleranceMeters: number) {
+        return unifyCloseCoordinates(this.network, toleranceMeters);
     }
 }

--- a/src/graph/methods/connected.spec.ts
+++ b/src/graph/methods/connected.spec.ts
@@ -2,7 +2,8 @@ import { FeatureCollection, LineString } from 'geojson';
 import { graphGetConnectedComponentCount, graphGetConnectedComponents } from './connected';
 import { generateTreeFeatureCollection } from '../../test-utils/generate-network';
 import { createFeatureCollection, createLineStringFeature } from '../../test-utils/create';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
+import { unifyCloseCoordinates } from './unify';
 
 describe('countConnectedComponents', () => {
     describe('for an empty feature collection', () => {
@@ -214,4 +215,5 @@ describe('splitIntoConnectedComponents', () => {
         const countMultipleCC = graphGetConnectedComponentCount(networkMultipleCC);
         expect(componentsMultipleCC.length).toBe(countMultipleCC);
     });
+
 })

--- a/src/graph/methods/spatial-index/geokdbush.spec.ts
+++ b/src/graph/methods/spatial-index/geokdbush.spec.ts
@@ -1,0 +1,86 @@
+import { KDBush } from './kdbush';
+import { around, distance } from './geokdbush';
+
+describe('geokdbush', () => {
+    const points = [
+        [0, 0], [1, 1], [2, 2], [3, 3],
+        [1, 0], [0, 1], [3, 2], [2, 3]
+    ];
+    const index = new KDBush(points.length);
+    for (const p of points) {
+        index.add(p[0], p[1]);
+    }
+    index.finish();
+
+    it('should return points within a given radius', () => {
+        const d = distance(0, 0, 1, 1);
+        const result = around(index, 0, 0, Infinity, d + 1);
+        const resultPoints = result.map(i => points[i]);
+        expect(resultPoints).toEqual(expect.arrayContaining([
+            [0, 0], [1, 1], [1, 0], [0, 1]
+        ]));
+        expect(resultPoints.length).toBe(4);
+    });
+
+    it('defaults to maxResults and maxDistance being Infinity', () => {
+        const result = around(index, 0, 0);
+        expect(result.length).toBe(points.length);
+        const resultPoints = result.map(i => points[i]);
+        expect(resultPoints).toEqual(expect.arrayContaining(points));
+    });
+
+    it('should return an empty array if no points are within the radius', () => {
+        const result = around(index, 10, 10, Infinity, 1);
+        expect(result).toEqual([]);
+    });
+
+    it('should handle maxResults correctly', () => {
+        const result = around(index, 0, 0, 2);
+        expect(result.length).toBe(2);
+    });
+
+    it('should also export a distance function', () => {
+        expect(distance(0, 0, 1, 1)).toBeCloseTo(157.2493, 2);
+    });
+
+    describe('with a larger number of points', () => {
+        const largePoints: [number, number][] = [];
+        for (let i = 0; i < 1000; i++) {
+            // Points around London
+            largePoints.push([
+                -0.1278 + (Math.random() - 0.5) * 2,
+                51.5074 + (Math.random() - 0.5) * 2
+            ]);
+        }
+        const index = new KDBush(largePoints.length, 16);
+        for (const p of largePoints) {
+            index.add(p[0], p[1]);
+        }
+        index.finish();
+
+        it('should find points around a location', () => {
+            const results = around(index, -0.1278, 51.5074, 10);
+            expect(results.length).toBe(10);
+            results.forEach(i => {
+                const p = largePoints[i];
+                expect(distance(p[0], p[1], -0.1278, 51.5074)).toBeLessThan(200); // 200km, rough check
+            });
+        });
+
+        it('should find points within a radius', () => {
+            const results = around(index, -0.1278, 51.5074, Infinity, 10); // 10km radius
+            expect(results.length).toBeGreaterThan(0);
+            results.forEach(i => {
+                const p = largePoints[i];
+                expect(distance(p[0], p[1], -0.1278, 51.5074)).toBeLessThanOrEqual(10);
+            });
+        });
+    });
+
+    it('should work with maxResults being undefined', () => {
+        const result = around(index, 0, 0, undefined);
+        expect(result.length).toBe(points.length);
+    });
+
+
+});

--- a/src/graph/methods/spatial-index/geokdbush.ts
+++ b/src/graph/methods/spatial-index/geokdbush.ts
@@ -1,0 +1,189 @@
+// Adapted from https://github.com/mourner/geokdbush
+
+// ISC License
+
+// Copyright (c) 2017, Vladimir Agafonkin
+
+// Permission to use, copy, modify, and/or distribute this software for any purpose
+// with or without fee is hereby granted, provided that the above copyright notice
+// and this permission notice appear in all copies.
+
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+// OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+// TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+// THIS SOFTWARE.
+
+import { KDBush } from './kdbush';
+import TinyQueue from './tinyqueue';
+
+const earthRadius = 6371;
+const rad = Math.PI / 180;
+
+
+// Distance is in kilometers
+export function around(index: KDBush, lng: number, lat: number, maxResults = Infinity, maxDistanceKm = Infinity) {
+    let maxHaverSinDist = 1;
+    const result = [];
+
+    if (maxResults === undefined) {
+        maxResults = Infinity;
+    }
+
+    if (maxDistanceKm !== undefined) {
+        maxHaverSinDist = haverSin(maxDistanceKm / earthRadius);
+    }
+
+    // a distance-sorted priority queue that will contain both points and kd-tree nodes
+    const q = new TinyQueue([], compareDist);
+
+    // an object that represents the top kd-tree node (the whole Earth)
+    let node = {
+        left: 0, // left index in the kd-tree array
+        right: index.ids.length - 1, // right index
+        axis: 0, // 0 for longitude axis and 1 for latitude axis
+        dist: 0, // will hold the lower bound of children's distances to the query point
+        minLng: -180, // bounding box of the node
+        minLat: -90,
+        maxLng: 180,
+        maxLat: 90
+    };
+
+    const cosLat = Math.cos(lat * rad);
+
+    while (node) {
+        const right = node.right;
+        const left = node.left;
+
+        if (right - left <= index.nodeSize) { // leaf node
+
+            // add all points of the leaf node to the queue
+            for (let i = left; i <= right; i++) {
+                const id = index.ids[i];
+
+                const dist = haverSinDist(lng, lat, index.coords[2 * i], index.coords[2 * i + 1], cosLat);
+                q.push({ id, dist });
+            }
+
+        } else { // not a leaf node (has child nodes)
+
+            const m = (left + right) >> 1; // middle index
+            const midLng = index.coords[2 * m];
+            const midLat = index.coords[2 * m + 1];
+
+            // add middle point to the queue
+            const id = index.ids[m];
+            const dist = haverSinDist(lng, lat, midLng, midLat, cosLat);
+            q.push({ id, dist });
+
+
+            const nextAxis = (node.axis + 1) % 2;
+
+            // first half of the node
+            const leftNode = {
+                left,
+                right: m - 1,
+                axis: nextAxis,
+                minLng: node.minLng,
+                minLat: node.minLat,
+                maxLng: node.axis === 0 ? midLng : node.maxLng,
+                maxLat: node.axis === 1 ? midLat : node.maxLat,
+                dist: 0
+            };
+            // second half of the node
+            const rightNode = {
+                left: m + 1,
+                right,
+                axis: nextAxis,
+                minLng: node.axis === 0 ? midLng : node.minLng,
+                minLat: node.axis === 1 ? midLat : node.minLat,
+                maxLng: node.maxLng,
+                maxLat: node.maxLat,
+                dist: 0
+            };
+
+            leftNode.dist = boxDist(lng, lat, cosLat, leftNode);
+            rightNode.dist = boxDist(lng, lat, cosLat, rightNode);
+
+            // add child nodes to the queue
+            q.push(leftNode);
+            q.push(rightNode);
+        }
+
+        // fetch closest points from the queue; they're guaranteed to be closer
+        // than all remaining points (both individual and those in kd-tree nodes),
+        // since each node's distance is a lower bound of distances to its children
+        while (q.length && q.peek().id != null) {
+            const candidate = q.pop()!;
+            if (candidate.dist > maxHaverSinDist) return result;
+            result.push(candidate.id);
+            if (result.length === maxResults) return result;
+        }
+
+        // the next closest kd-tree node
+        node = q.pop();
+    }
+
+    return result;
+}
+
+// lower bound for distance from a location to points inside a bounding box
+function boxDist(lng: number, lat: number, cosLat: number, node: any) {
+    const minLng = node.minLng;
+    const maxLng = node.maxLng;
+    const minLat = node.minLat;
+    const maxLat = node.maxLat;
+
+    // query point is between minimum and maximum longitudes
+    if (lng >= minLng && lng <= maxLng) {
+        if (lat < minLat) return haverSin((lat - minLat) * rad);
+        if (lat > maxLat) return haverSin((lat - maxLat) * rad);
+        return 0;
+    }
+
+    // query point is west or east of the bounding box;
+    // calculate the extremum for great circle distance from query point to the closest longitude;
+    const haverSinDLng = Math.min(haverSin((lng - minLng) * rad), haverSin((lng - maxLng) * rad));
+    const extremumLat = vertexLat(lat, haverSinDLng);
+
+    // if extremum is inside the box, return the distance to it
+    if (extremumLat > minLat && extremumLat < maxLat) {
+        return haverSinDistPartial(haverSinDLng, cosLat, lat, extremumLat);
+    }
+    // otherwise return the distan e to one of the bbox corners (whichever is closest)
+    return Math.min(
+        haverSinDistPartial(haverSinDLng, cosLat, lat, minLat),
+        haverSinDistPartial(haverSinDLng, cosLat, lat, maxLat)
+    );
+}
+
+function compareDist(a: any, b: any) {
+    return a.dist - b.dist;
+}
+
+function haverSin(theta: number) {
+    const s = Math.sin(theta / 2);
+    return s * s;
+}
+
+function haverSinDistPartial(haverSinDLng: number, cosLat1: number, lat1: number, lat2: number) {
+    return cosLat1 * Math.cos(lat2 * rad) * haverSinDLng + haverSin((lat1 - lat2) * rad);
+}
+
+function haverSinDist(lng1: number, lat1: number, lng2: number, lat2: number, cosLat1: number) {
+    const haverSinDLng = haverSin((lng1 - lng2) * rad);
+    return haverSinDistPartial(haverSinDLng, cosLat1, lat1, lat2);
+}
+
+export function distance(lng1: number, lat1: number, lng2: number, lat2: number) {
+    const h = haverSinDist(lng1, lat1, lng2, lat2, Math.cos(lat1 * rad));
+    return 2 * earthRadius * Math.asin(Math.sqrt(h));
+}
+
+function vertexLat(lat: number, haverSinDLng: number) {
+    const cosDLng = 1 - 2 * haverSinDLng;
+    if (cosDLng <= 0) return lat > 0 ? 90 : -90;
+    return Math.atan(Math.tan(lat * rad) / cosDLng) / rad;
+}

--- a/src/graph/methods/spatial-index/kdbush.spec.ts
+++ b/src/graph/methods/spatial-index/kdbush.spec.ts
@@ -1,0 +1,67 @@
+import { KDBush } from './kdbush';
+
+describe('KDBush', () => {
+    const points = [
+        [0, 0], [1, 1], [2, 2], [3, 3],
+        [1, 0], [0, 1], [3, 2], [2, 3]
+    ];
+
+    it('should build an index correctly', () => {
+        const index = new KDBush(points.length);
+        for (const p of points) {
+            index.add(p[0], p[1]);
+        }
+        index.finish();
+
+        expect(index.ids.length).toBe(points.length);
+        expect(index.coords.length).toBe(points.length * 2);
+        // Check if ids are a permutation of 0..n-1
+        expect(Array.from(index.ids).sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it('should throw an error if finish is called with wrong number of points', () => {
+        const index = new KDBush(points.length);
+        index.add(0, 0);
+        expect(() => index.finish()).toThrow('Added 1 items when expected 8.');
+    });
+
+    it('should handle different array types', () => {
+        const index = new KDBush(points.length, 64, Float32Array);
+        for (const p of points) {
+            index.add(p[0], p[1]);
+        }
+        index.finish();
+        expect(index.coords).toBeInstanceOf(Float32Array);
+    });
+
+    it('should throw on invalid numItems', () => {
+        expect(() => new KDBush(-1)).toThrow('Unexpected numItems value: -1.');
+        expect(() => new KDBush(NaN)).toThrow('Unexpected numItems value: NaN.');
+    });
+
+    it('should throw on invalid ArrayType', () => {
+        // @ts-expect-error
+        expect(() => new KDBush(1, 64, Array)).toThrow('Unexpected typed array class: function Array() { [native code] }');
+    });
+
+    it('should reconstruct an index from data', () => {
+        const index = new KDBush(points.length);
+        for (const p of points) {
+            index.add(p[0], p[1]);
+        }
+        index.finish();
+
+        const data = index.data;
+        const index2 = new KDBush(points.length, 64, Float64Array, data);
+
+        expect(index2.ids).toEqual(index.ids);
+        expect(index2.coords).toEqual(index.coords);
+        expect(index2.numItems).toBe(index.numItems);
+        expect(index2.nodeSize).toBe(index.nodeSize);
+    });
+
+    it('should use Uint32Array for large number of items', () => {
+        const index = new KDBush(70000);
+        expect(index.ids).toBeInstanceOf(Uint32Array);
+    });
+});

--- a/src/graph/methods/spatial-index/kdbush.ts
+++ b/src/graph/methods/spatial-index/kdbush.ts
@@ -1,0 +1,189 @@
+// Adapted from https://github.com/mourner/kdbush
+
+// ISC License
+
+// Copyright (c) 2018, Vladimir Agafonkin
+
+// Permission to use, copy, modify, and/or distribute this software for any purpose
+// with or without fee is hereby granted, provided that the above copyright notice
+// and this permission notice appear in all copies.
+
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+// OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+// TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+// THIS SOFTWARE.
+
+const ARRAY_TYPES = [
+    Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
+    Int32Array, Uint32Array, Float32Array, Float64Array
+];
+
+const VERSION = 1;
+const HEADER_SIZE = 8;
+
+export class KDBush {
+    public data: ArrayBuffer;
+    public ids: Uint16Array | Uint32Array;
+    public coords: InstanceType<TypedArrayConstructor>;
+    private _pos: number;
+    private _finished: boolean;
+    public numItems: number;
+    public nodeSize: number;
+    private ArrayType: TypedArrayConstructor;
+    private IndexArrayType: typeof Uint16Array | typeof Uint32Array;
+
+    constructor(
+        numItems: number,
+        nodeSize: number = 64,
+        ArrayType: TypedArrayConstructor = Float64Array,
+        data?: ArrayBuffer
+    ) {
+        if (isNaN(numItems) || numItems < 0) {
+            throw new Error(`Unexpected numItems value: ${numItems}.`);
+        }
+
+        this.numItems = numItems;
+        this.nodeSize = Math.min(Math.max(nodeSize, 2), 65535);
+        this.ArrayType = ArrayType;
+        this.IndexArrayType = numItems < 65536 ? Uint16Array : Uint32Array;
+
+        const arrayTypeIndex = ARRAY_TYPES.indexOf(this.ArrayType);
+        const coordsByteSize = numItems * 2 * this.ArrayType.BYTES_PER_ELEMENT;
+        const idsByteSize = numItems * this.IndexArrayType.BYTES_PER_ELEMENT;
+        const padCoords = (8 - idsByteSize % 8) % 8;
+
+        if (arrayTypeIndex < 0) {
+            throw new Error(`Unexpected typed array class: ${ArrayType}.`);
+        }
+
+        if (data) {
+            this.data = data;
+            this.ids = new (this.IndexArrayType as any)(this.data, HEADER_SIZE, numItems);
+            this.coords = new (this.ArrayType as any)(this.data, HEADER_SIZE + idsByteSize + padCoords, numItems * 2);
+            this._pos = numItems * 2;
+            this._finished = true;
+        } else {
+            this.data = new ArrayBuffer(HEADER_SIZE + coordsByteSize + idsByteSize + padCoords);
+            this.ids = new (this.IndexArrayType as any)(this.data, HEADER_SIZE, numItems);
+            this.coords = new (this.ArrayType as any)(this.data, HEADER_SIZE + idsByteSize + padCoords, numItems * 2);
+            this._pos = 0;
+            this._finished = false;
+
+            new Uint8Array(this.data, 0, 2).set([0xdb, (VERSION << 4) + arrayTypeIndex]);
+            new Uint16Array(this.data, 2, 1)[0] = this.nodeSize;
+            new Uint32Array(this.data, 4, 1)[0] = this.numItems;
+        }
+    }
+
+    add(x: number, y: number): number {
+        const index = this._pos >> 1;
+        this.ids[index] = index;
+        this.coords[this._pos++] = x;
+        this.coords[this._pos++] = y;
+        return index;
+    }
+
+    finish(): this {
+        const numAdded = this._pos >> 1;
+        if (numAdded !== this.numItems) {
+            throw new Error(`Added ${numAdded} items when expected ${this.numItems}.`);
+        }
+        sort(this.ids, this.coords, this.nodeSize, 0, this.numItems - 1, 0);
+        this._finished = true;
+        return this;
+    }
+}
+
+type TypedArrayConstructor =
+    Int8ArrayConstructor | Uint8ArrayConstructor | Uint8ClampedArrayConstructor |
+    Int16ArrayConstructor | Uint16ArrayConstructor |
+    Int32ArrayConstructor | Uint32ArrayConstructor |
+    Float32ArrayConstructor | Float64ArrayConstructor;
+
+function sort(
+    ids: Uint16Array | Uint32Array,
+    coords: InstanceType<TypedArrayConstructor>,
+    nodeSize: number,
+    left: number,
+    right: number,
+    axis: number
+): void {
+    if (right - left <= nodeSize) return;
+    const m = (left + right) >> 1;
+    select(ids, coords, m, left, right, axis);
+    sort(ids, coords, nodeSize, left, m - 1, 1 - axis);
+    sort(ids, coords, nodeSize, m + 1, right, 1 - axis);
+}
+
+function select(
+    ids: Uint16Array | Uint32Array,
+    coords: InstanceType<TypedArrayConstructor>,
+    k: number,
+    left: number,
+    right: number,
+    axis: number
+): void {
+    while (right > left) {
+        if (right - left > 600) {
+            const n = right - left + 1;
+            const m = k - left + 1;
+            const z = Math.log(n);
+            const s = 0.5 * Math.exp(2 * z / 3);
+            const sd = 0.5 * Math.sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
+            const newLeft = Math.max(left, Math.floor(k - m * s / n + sd));
+            const newRight = Math.min(right, Math.floor(k + (n - m) * s / n + sd));
+            select(ids, coords, k, newLeft, newRight, axis);
+        }
+
+        const t = coords[2 * k + axis];
+        let i = left;
+        let j = right;
+
+        swapItem(ids, coords, left, k);
+        if (coords[2 * right + axis] > t) {
+            swapItem(ids, coords, left, right);
+        }
+
+        while (i < j) {
+            swapItem(ids, coords, i, j);
+            i++;
+            j--;
+            while (coords[2 * i + axis] < t) i++;
+            while (coords[2 * j + axis] > t) j--;
+        }
+
+        if (coords[2 * left + axis] === t) {
+            swapItem(ids, coords, left, j);
+        } else {
+            j++;
+            swapItem(ids, coords, j, right);
+        }
+
+        if (j <= k) left = j + 1;
+        if (k <= j) right = j - 1;
+    }
+}
+
+function swapItem(
+    ids: Uint16Array | Uint32Array,
+    coords: InstanceType<TypedArrayConstructor>,
+    i: number,
+    j: number
+): void {
+    swap(ids, i, j);
+    swap(coords, 2 * i, 2 * j);
+    swap(coords, 2 * i + 1, 2 * j + 1);
+}
+
+function swap<T extends Uint16Array | Uint32Array | Float32Array | Float64Array | Int8Array | Int16Array | Int32Array | Uint8Array | Uint8ClampedArray>(
+    arr: T,
+    i: number,
+    j: number
+): void {
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+}

--- a/src/graph/methods/spatial-index/tinyqueue.spec.ts
+++ b/src/graph/methods/spatial-index/tinyqueue.spec.ts
@@ -1,0 +1,51 @@
+import TinyQueue from './tinyqueue';
+
+describe('TinyQueue', () => {
+    it('should create a queue', () => {
+        const queue = new TinyQueue();
+        expect(queue).toBeDefined();
+    });
+
+    it('should push and pop items', () => {
+        const queue = new TinyQueue<{ value: number }>([], (a, b) => a.value - b.value);
+        queue.push({ value: 3 });
+        queue.push({ value: 1 });
+        queue.push({ value: 2 });
+
+        expect(queue.pop()?.value).toBe(1);
+        expect(queue.pop()?.value).toBe(2);
+        expect(queue.pop()?.value).toBe(3);
+        expect(queue.pop()).toBeUndefined();
+    });
+
+    it('should peek at the top item', () => {
+        const queue = new TinyQueue<{ value: number }>([], (a, b) => a.value - b.value);
+        queue.push({ value: 3 });
+        queue.push({ value: 1 });
+        queue.push({ value: 2 });
+
+        expect(queue.peek()?.value).toBe(1);
+        queue.pop();
+        expect(queue.peek()?.value).toBe(2);
+    });
+
+    it('should handle an empty queue', () => {
+        const queue = new TinyQueue();
+        expect(queue.pop()).toBeUndefined();
+        expect(queue.peek()).toBeUndefined();
+    });
+
+    it('should handle initial data', () => {
+        const data = [{ value: 3 }, { value: 1 }, { value: 2 }];
+        const queue = new TinyQueue<{ value: number }>(data, (a, b) => a.value - b.value);
+        expect(queue.pop()?.value).toBe(1);
+    });
+
+    it('should use default comparator', () => {
+        const queue = new TinyQueue<number>();
+        queue.push(3);
+        queue.push(1);
+        queue.push(2);
+        expect(queue.pop()).toBe(1);
+    });
+});

--- a/src/graph/methods/spatial-index/tinyqueue.ts
+++ b/src/graph/methods/spatial-index/tinyqueue.ts
@@ -1,0 +1,108 @@
+// Adapted from https://github.com/mourner/kdbush
+
+// ISC License
+
+// Copyright (c) 2017, Vladimir Agafonkin
+
+// Permission to use, copy, modify, and/or distribute this software for any purpose
+// with or without fee is hereby granted, provided that the above copyright notice
+// and this permission notice appear in all copies.
+
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+// OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+// TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+// THIS SOFTWARE.
+
+export default class TinyQueue<T> {
+
+    private data: T[];
+    public length: number;
+    private compare: (a: T, b: T) => number;
+
+    constructor(
+        data: T[] = [],
+        compare: (a: T, b: T) => number = (a, b) =>
+            a < b ? -1 : a > b ? 1 : 0
+    ) {
+        this.data = data;
+        this.length = this.data.length;
+        this.compare = compare;
+
+        if (this.length > 0) {
+            for (let i = (this.length >> 1) - 1; i >= 0; i--) {
+                this._down(i);
+            }
+        }
+    }
+
+    push(item: T): void {
+        this.data.push(item);
+        this._up(this.length++);
+    }
+
+    pop(): T | undefined {
+        if (this.length === 0) {
+            return undefined;
+        }
+
+        const top = this.data[0];
+        const bottom = this.data.pop() as T;
+
+        this.length--;
+
+        if (this.length > 0) {
+            this.data[0] = bottom;
+            this._down(0);
+        }
+
+        return top;
+    }
+
+    peek(): T | undefined {
+        return this.data[0];
+    }
+
+    private _up(pos: number): void {
+        const { data, compare } = this;
+        const item = data[pos];
+
+        while (pos > 0) {
+            const parent = (pos - 1) >> 1;
+            const current = data[parent];
+            if (compare(item, current) >= 0) {
+                break;
+            }
+            data[pos] = current;
+            pos = parent;
+        }
+
+        data[pos] = item;
+    }
+
+    private _down(pos: number): void {
+        const { data, compare } = this;
+        const halfLength = this.length >> 1;
+        const item = data[pos];
+
+        while (pos < halfLength) {
+            let bestChild = (pos << 1) + 1;
+            const right = bestChild + 1;
+
+            if (right < this.length && compare(data[right], data[bestChild]) < 0) {
+                bestChild = right;
+            }
+
+            if (compare(data[bestChild], item) >= 0) {
+                break;
+            }
+
+            data[pos] = data[bestChild];
+            pos = bestChild;
+        }
+
+        data[pos] = item;
+    }
+}

--- a/src/graph/methods/unify.spec.ts
+++ b/src/graph/methods/unify.spec.ts
@@ -1,0 +1,475 @@
+import { FeatureCollection, LineString } from 'geojson';
+import { unifyCloseCoordinates } from './unify';
+import { getReasonIfLineStringInvalid } from '../../test-utils/utils';
+import { graphGetConnectedComponentCount } from './connected';
+import { graphGetNodeAndEdgeCount } from './nodes';
+import { createFeatureCollection, createLineStringFeature } from '../../test-utils/create';
+
+describe('unifyCloseCoordinates', () => {
+    describe('for an empty feature collection', () => {
+        it('returns an empty feature collection', () => {
+            const input: FeatureCollection<LineString> = {
+                type: 'FeatureCollection',
+                features: []
+            };
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(output).toEqual({
+                type: 'FeatureCollection',
+                features: []
+            });
+        });
+    });
+
+    describe('for a single linestring', () => {
+        it('does not modify coordinates', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001], // ~1.5m apart
+                    [0.00002, 0.00002] // ~1.5m apart
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+            const coords = output.features[0].geometry.coordinates;
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+
+            expect(coords).toHaveLength(3); // Should unify to a single coordinate
+            expect(coords[0]).toEqual([0, 0]); // Both coordinates should unify to the first one
+            expect(coords[1]).toEqual([0.00001, 0.00001]); // Both coordinates should unify to the first one
+            expect(coords[2]).toEqual([0.00002, 0.00002]); // Both coordinates should unify to the first one
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 3, edgeCount: 2 });
+        });
+    });
+
+    describe('for two linestrings', () => {
+        it('does nothing if linestrings are already connected', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00001, 0.00001],
+                    [0.00002, 0.00002] // ~1.5m apart
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([0.00001, 0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0.00001, 0.00001]);
+            expect(coordsTwo[1]).toEqual([0.00002, 0.00002]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 3, edgeCount: 2 });
+        });
+
+        it('unifies two nearby linestring coordinates if they are within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00002, 0.00002],
+                    [0.00003, 0.00003] // ~1.5m apart
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([0.00001, 0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0.00001, 0.00001]);
+            expect(coordsTwo[1]).toEqual([0.00003, 0.00003]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 3, edgeCount: 2 });
+        });
+
+        it('does not unify coordinates if they are not within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [1, 1]
+                ]),
+                createLineStringFeature([
+                    [10, 10],
+                    [11, 11]
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([1, 1]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([10, 10]);
+            expect(coordsTwo[1]).toEqual([11, 11]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(2);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 4, edgeCount: 2 });
+        });
+
+        it('does unify both coordinates to corresponding coordinates in counterpart linestring if they are within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [1, 1]
+                ]),
+                createLineStringFeature([
+                    [0.000001, 0.000001],
+                    [1.000001, 1.000001]
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([1, 1]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0, 0]);
+            expect(coordsTwo[1]).toEqual([1, 1]);
+
+            // Only one because lines are now identical and connected
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 2, edgeCount: 1 });
+        });
+    });
+
+    describe('for multiple linestrings', () => {
+        it('does nothing if linestrings already connected', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00001, 0.00001],
+                    [0.00002, 0.00002] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00002, 0.00002],
+                    [0.00003, 0.00003] // ~1.5m apart
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([0.00001, 0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0.00001, 0.00001]);
+            expect(coordsTwo[1]).toEqual([0.00002, 0.00002]);
+
+            expect(getReasonIfLineStringInvalid(output.features[2])).toBeUndefined();
+            const coordsThree = output.features[2].geometry.coordinates;
+            expect(coordsThree).toHaveLength(2);
+            expect(coordsThree[0]).toEqual([0.00002, 0.00002]);
+            expect(coordsThree[1]).toEqual([0.00003, 0.00003]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 4, edgeCount: 3 });
+        });
+
+        it('does not unify any linestrings coordinates if they are not within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00002, 0.00002],
+                    [0.00003, 0.00003] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00004, 0.00004],
+                    [0.00005, 0.00005] // ~1.5m apart
+                ]),
+            ]);
+
+            // Note the reduced radiusMeters
+            const radiusMeters = 1; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([0.00001, 0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0.00002, 0.00002]);
+            expect(coordsTwo[1]).toEqual([0.00003, 0.00003]);
+
+            expect(getReasonIfLineStringInvalid(output.features[2])).toBeUndefined();
+            const coordsThree = output.features[2].geometry.coordinates;
+            expect(coordsThree).toHaveLength(2);
+            expect(coordsThree[0]).toEqual([0.00004, 0.00004]);
+            expect(coordsThree[1]).toEqual([0.00005, 0.00005]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(3);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 6, edgeCount: 3 });
+        });
+
+        it('unifies linestrings coordinates where they are within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00002, 0.00002],
+                    [0.00003, 0.00003] // ~1.5m apart
+                ]),
+                createLineStringFeature([
+                    [0.00004, 0.00004],
+                    [0.00005, 0.00005] // ~1.5m apart
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([0.00001, 0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0.00001, 0.00001]);
+            expect(coordsTwo[1]).toEqual([0.00003, 0.00003]);
+
+            expect(getReasonIfLineStringInvalid(output.features[2])).toBeUndefined();
+            const coordsThree = output.features[2].geometry.coordinates;
+            expect(coordsThree).toHaveLength(2);
+            expect(coordsThree[0]).toEqual([0.00003, 0.00003]);
+            expect(coordsThree[1]).toEqual([0.00005, 0.00005]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+            expect(graphGetNodeAndEdgeCount(output)).toEqual({ nodeCount: 4, edgeCount: 3 });
+
+        });
+
+        it('unifies closest coordinate of linestrings if they are within tolerance and there are multiple options', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001]
+                ]),
+                createLineStringFeature([
+                    [0.000011, 0.000011],
+                    [0.00003, 0.00003]
+                ]),
+                createLineStringFeature([
+                    [0.000012, 0.000012],
+                    [0.00005, 0.00005]
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([0.00001, 0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0.00001, 0.00001]);
+            expect(coordsTwo[1]).toEqual([0.00003, 0.00003]);
+
+            expect(getReasonIfLineStringInvalid(output.features[2])).toBeUndefined();
+            const coordsThree = output.features[2].geometry.coordinates;
+            expect(coordsThree).toHaveLength(2);
+            expect(coordsThree[0]).toEqual([0.00001, 0.00001]);
+            expect(coordsThree[1]).toEqual([0.00005, 0.00005]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+        });
+
+        it('unifies first coordinate where they are within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [0.00001, 0.00001]
+                ]),
+                // Going off in a different direction
+                createLineStringFeature([
+                    [0.000001, 0.000001],
+                    [-0.00001, -0.00001]
+                ]),
+                createLineStringFeature([
+                    [0.0000011, 0.0000011],
+                    [-0.00003, -0.00003]
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([0, 0]);
+            expect(coords[1]).toEqual([0.00001, 0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+            expect(coordsTwo[0]).toEqual([0, 0]);
+            expect(coordsTwo[1]).toEqual([-0.00001, -0.00001]);
+
+            expect(getReasonIfLineStringInvalid(output.features[2])).toBeUndefined();
+            const coordsThree = output.features[2].geometry.coordinates;
+            expect(coordsThree).toHaveLength(2);
+            expect(coordsThree[0]).toEqual([0, 0]);
+            expect(coordsThree[1]).toEqual([-0.00003, -0.00003]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+        });
+
+        it('unifies last coordinate where they are within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [-3, -3],
+                    [0, 0]
+                ]),
+                createLineStringFeature([
+                    [-1, -1],
+                    [0.000001, 0.000001]
+                ]),
+                createLineStringFeature([
+                    [-2, -2],
+                    [0.0000011, 0.0000011]
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(2);
+            expect(coords[0]).toEqual([-3, -3]);
+            expect(coords[1]).toEqual([0, 0]);
+
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(2);
+
+            expect(coordsTwo[0]).toEqual([-1, -1]);
+            expect(coordsTwo[1]).toEqual([0, 0]);
+
+
+            expect(getReasonIfLineStringInvalid(output.features[2])).toBeUndefined();
+            const coordsThree = output.features[2].geometry.coordinates;
+            expect(coordsThree).toHaveLength(2);
+            expect(coordsThree[0]).toEqual([-2, -2]);
+            expect(coordsThree[1]).toEqual([0, 0]);
+
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+        });
+
+        it('unifies middle coordinate where they are within tolerance', () => {
+            const input: FeatureCollection<LineString> = createFeatureCollection([
+                createLineStringFeature([
+                    [-1, -1],
+                    [0, 0],
+                    [1, 1]
+                ]),
+                createLineStringFeature([
+                    [-2, -2],
+                    [0.000001, 0.000001],
+                    [2, 2]
+                ]),
+                createLineStringFeature([
+                    [-3, -3],
+                    [0.0000011, 0.0000011],
+                    [3, 3]
+                ]),
+            ]);
+
+            const radiusMeters = 2; // meters
+            const output = unifyCloseCoordinates(input, radiusMeters);
+
+            expect(getReasonIfLineStringInvalid(output.features[0])).toBeUndefined();
+            const coords = output.features[0].geometry.coordinates;
+            expect(coords).toHaveLength(3);
+            expect(coords[0]).toEqual([-1, -1]);
+            expect(coords[1]).toEqual([0, 0]);
+            expect(coords[2]).toEqual([1, 1]);
+
+            expect(getReasonIfLineStringInvalid(output.features[1])).toBeUndefined();
+            const coordsTwo = output.features[1].geometry.coordinates;
+            expect(coordsTwo).toHaveLength(3);
+            expect(coordsTwo[0]).toEqual([-2, -2]);
+            expect(coordsTwo[1]).toEqual([0, 0]);
+            expect(coordsTwo[2]).toEqual([2, 2]);
+
+            expect(getReasonIfLineStringInvalid(output.features[2])).toBeUndefined();
+            const coordsThree = output.features[2].geometry.coordinates;
+            expect(coordsThree).toHaveLength(3);
+            expect(coordsThree[0]).toEqual([-3, -3]);
+            expect(coordsThree[1]).toEqual([0, 0]);
+            expect(coordsThree[2]).toEqual([3, 3]);
+
+            expect(graphGetConnectedComponentCount(output)).toBe(1);
+        });
+    });
+});

--- a/src/graph/methods/unify.ts
+++ b/src/graph/methods/unify.ts
@@ -1,0 +1,132 @@
+import { FeatureCollection, LineString, Position } from 'geojson';
+import { haversineDistance } from '../../terra-route';
+import { KDBush } from './spatial-index/kdbush';
+import { around } from './spatial-index/geokdbush';
+
+export function unifyCloseCoordinates(
+    featureCollection: FeatureCollection<LineString>,
+    radiusMeters: number
+): FeatureCollection<LineString> {
+    if (featureCollection.features.length < 2) {
+        return featureCollection; // No features to process
+    }
+
+    const globalSeen: Position[] = [];
+    const globalSeenSet = new Set<string>(); // Fast O(1) lookup for globalSeen
+    const mapping: Map<string, Position> = new Map();
+
+    // Build a one-time spatial index with all coordinates for efficient querying
+    const allCoords: Position[] = [];
+    const coordToGlobalIndex = new Map<string, number>();
+
+    // Collect all unique coordinates first
+    for (const feature of featureCollection.features) {
+        for (const coord of feature.geometry.coordinates) {
+            const key = `${coord[0]},${coord[1]}`; // Faster than join
+            if (!coordToGlobalIndex.has(key)) {
+                coordToGlobalIndex.set(key, allCoords.length);
+                allCoords.push(coord);
+            }
+        }
+    }
+
+    // Build spatial index once for all coordinates
+    let spatialIndex: KDBush = new KDBush(allCoords.length);
+    for (const coord of allCoords) {
+        spatialIndex.add(coord[0], coord[1]); // lng, lat
+    }
+    spatialIndex.finish();
+
+    function findOrRegisterCoordinate(
+        coordinate: Position,
+        exclude: Position[],
+        futureConflictCheck: Set<string>
+    ): Position {
+        let closest: Position | null = null;
+        let closestDistance = Infinity;
+
+        // if (globalSeen.length > 5) {
+        // Use spatial index for efficient querying
+        const radiusKm = radiusMeters / 1000; // Convert meters to kilometers
+        const candidateIndices = around(spatialIndex, coordinate[0], coordinate[1], Infinity, radiusKm);
+
+        for (const candidateIndex of candidateIndices) {
+            const candidateCoord = allCoords[candidateIndex];
+            const candidateKey = `${candidateCoord[0]},${candidateCoord[1]}`;
+
+            // Only consider coordinates that are in globalSeen (O(1) lookup)
+            if (!globalSeenSet.has(candidateKey)) {
+                continue;
+            }
+
+            if (exclude.includes(candidateCoord)) {
+                continue;
+            }
+
+            if (futureConflictCheck.has(candidateKey)) {
+                continue;
+            }
+
+            const distance = haversineDistance(candidateCoord, coordinate) * 1000; // Convert to meters
+
+            if (distance <= radiusMeters && distance < closestDistance) {
+                closest = candidateCoord;
+                closestDistance = distance;
+            }
+        }
+
+
+        if (closest !== null) {
+            return closest;
+        }
+
+        globalSeen.push(coordinate);
+        globalSeenSet.add(`${coordinate[0]},${coordinate[1]}`);
+        return coordinate;
+    }
+
+    const updatedFeatures = featureCollection.features.map((feature) => {
+        const localSeen: Position[] = [];
+        const updatedCoordinates: Position[] = [];
+        const usedKeys = new Set<string>();
+
+        for (const coordinate of feature.geometry.coordinates) {
+            const key = `${coordinate[0]},${coordinate[1]}`;
+
+            if (!mapping.has(key)) {
+                const unified = findOrRegisterCoordinate(coordinate, localSeen, usedKeys);
+                const unifiedKey = `${unified[0]},${unified[1]}`;
+
+                // Avoid inserting a coordinate if it's going to cause duplication later in this feature
+                if (usedKeys.has(unifiedKey)) {
+                    mapping.set(key, coordinate);
+                } else {
+                    mapping.set(key, unified);
+                }
+            }
+
+            const unifiedCoordinate = mapping.get(key)!;
+            const unifiedKey = `${unifiedCoordinate[0]},${unifiedCoordinate[1]}`;
+
+            if (!usedKeys.has(unifiedKey)) {
+                updatedCoordinates.push(unifiedCoordinate);
+                usedKeys.add(unifiedKey);
+            }
+
+            localSeen.push(coordinate);
+        }
+
+        return {
+            ...feature,
+            geometry: {
+                ...feature.geometry,
+                coordinates: updatedCoordinates
+            }
+        };
+    });
+
+    return {
+        ...featureCollection,
+        features: updatedFeatures
+    };
+}


### PR DESCRIPTION
## Description of Changes

This PR adds functionality to unify points in a graph where there is a very small tolerance between them. This is useful for scenarios where a graph is a bit noisy and there isn't a perfect unification of coordinates in the LineStrings (i.e. some fractional distance like a few millimeters/centimeters) 

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 