### PR TITLE
perf: improve performance by using Four-ary Heap and Compressed Sparse Row

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p></p>
 
-Terra Route aims to be a fast library for routing on GeoJSON LineStrings networks, where LineStrings share identical coordinates. Terra Routes main aim is currently performance - it uses A* to help achieve this.
+Terra Route aims to be a fast library for routing on GeoJSON LineStrings networks, where LineStrings share identical coordinates. 
 
 ## Install
 
@@ -47,7 +47,7 @@ console.log("Shortest route:", JSON.stringify(route, null, 2));
 
 ## Additional Functionality
 
-Terra Route also exposes functionality for understanding GeoJSON route networks better called `LineStringGraph`. This can be useful for debugging as this class has a series of methods for determining things like unique nodes, edges, connected components as well as all their counts. With this class you can understand your graph better programmatically, for example determining it's size and if it is correctly connected.
+Terra Route provides a utility called LineStringGraph for analyzing GeoJSON route networks. This class is especially useful for debugging, as it includes methods to identify unique nodes, edges, and connected components, along with their counts. Beyond debugging, these methods help you programmatically explore and understand the structure of your graph — for example, by measuring its size and examining how its parts are connected.
 
 ```typescript
 const graph = new LineStringGraph(network);
@@ -57,9 +57,6 @@ const graphPoints = graph.getNodes();
 
 // Return all the unique edges as FeatureCollection<LineString>, where each unique edge is a Feature<LineString>
 const graphEdges = graph.getEdges(); 
-
-// The longest possible shortest path in the graph between two nodes (i.e. graph diameter)
-const longestShortestPath = graph.getMaxLengthShortestPath()
 ```
 
 ## Benchmarks
@@ -73,14 +70,16 @@ npm run benchmark
 Here is an example output of a benchmark run for routing:
 
 <pre>
-Terra Route         | ███████████ 270ms
-GeoJSON Path Finder | █████████████████████████ 591ms
-ngraph.graph        | ██████████████████████████████████████████████████ 1177ms
+Terra Route          | ██████ 186ms
+GeoJSON Path Finder  | ██████████████████ 566ms
+ngraph.graph         | ██████████████████████████████████████████████████ 1577ms
 </pre>
 
-Using default Haversine distance, Terra Route is approximately 2x faster than GeoJSON Path Finder with Haversine distance for A -> B path finding. If you pass in the CheapRuler distance metric (you can use the exposed `createCheapRuler` function), it is approximately x5 faster than GeoJSON Path Finder with Haversine distance. 
+Using default Haversine distance, Terra Route is approximately 3x faster than GeoJSON Path Finder with Haversine distance for A -> B path finding. If you pass in the CheapRuler distance metric (you can use the exposed `createCheapRuler` function), it is approximately x8 faster than GeoJSON Path Finder with Haversine distance. 
 
 For initialisation of the network, Terra Route is approximately 10x faster with Haversine than GeoJSON Path Finder. Terra Draw splits out instantiating the Class of the library from the actual graph building, which is done via `buildRouteGraph`. This allows you to defer graph creation to an appropriate time.
+
+Terra Route uses an [A* algorthm for pathfinding](https://en.wikipedia.org/wiki/A*_search_algorithm) and by default uses a [four-ary heap](https://en.wikipedia.org/wiki/D-ary_heap) for the underlying priority queue, although this is configurable. 
 
 ## Limitations
 

--- a/benchmark/benchmarks/terra-route-min.benchmark.ts
+++ b/benchmark/benchmarks/terra-route-min.benchmark.ts
@@ -4,15 +4,16 @@ import { createRoutingBenchmark } from "./../create-benchmark";
 // Terra Route
 import { TerraRoute } from "../../src/terra-route";
 import { BenchmarkProps } from "../registered-benchmarks";
+import { MinHeap } from "../../src/heap/min-heap";
 
-export const CreateTerraRouteBenchmark = ({
+export const CreateTerraRouteMinHeapBenchmark = ({
     network,
     pairs,
     enabled
 }: BenchmarkProps) => createRoutingBenchmark(
-    'Terra Route (Default Four-ary Heap)',
+    'Terra Route with Min Heap',
     () => {
-        const terraRoute = new TerraRoute();
+        const terraRoute = new TerraRoute({ heap: MinHeap });
         terraRoute.buildRouteGraph(network);
         return terraRoute
     },

--- a/benchmark/benchmarks/terra-route.benchmark.ts
+++ b/benchmark/benchmarks/terra-route.benchmark.ts
@@ -10,7 +10,7 @@ export const CreateTerraRouteBenchmark = ({
     pairs,
     enabled
 }: BenchmarkProps) => createRoutingBenchmark(
-    'Terra Route (Default Four-ary Heap)',
+    'Terra Route',
     () => {
         const terraRoute = new TerraRoute();
         terraRoute.buildRouteGraph(network);

--- a/benchmark/registered-benchmarks.ts
+++ b/benchmark/registered-benchmarks.ts
@@ -24,9 +24,9 @@ export const registeredBenchmarks = (network: FeatureCollection<LineString>, pai
 
         // Others
         CreateTerraRouteCheapRulerBenchmark({ ...parameters, enabled: false }),
-        CreateTerraRouteFibonacciBenchmark({ ...parameters, enabled: true }),
-        CreateTerraRoutePairingBenchmark({ ...parameters, enabled: true }),
-        CreateTerraRouteMinHeapBenchmark({ ...parameters, enabled: true }),
+        CreateTerraRouteFibonacciBenchmark({ ...parameters, enabled: false }),
+        CreateTerraRoutePairingBenchmark({ ...parameters, enabled: false }),
+        CreateTerraRouteMinHeapBenchmark({ ...parameters, enabled: false }),
         CreateTerraRouteCheapRulerBenchmark({ ...parameters, enabled: false }),
         CreateNgraphGraphBenchmark({ ...parameters, enabled: false }),
     ])

--- a/benchmark/registered-benchmarks.ts
+++ b/benchmark/registered-benchmarks.ts
@@ -6,6 +6,7 @@ import { CreateTerraRouteFibonacciBenchmark } from "./benchmarks/terra-route-fib
 import { CreateTerraRoutePairingBenchmark } from "./benchmarks/terra-route-pairing.benchmark";
 import { CreateTerraRouteCheapRulerBenchmark } from "./benchmarks/terra-route-cheap-ruler.benchmark";
 import { CreateGeoJSONPathFinderBenchmark } from "./benchmarks/geojson-pathfinder.benchmark";
+import { CreateTerraRouteMinHeapBenchmark } from "./benchmarks/terra-route-min.benchmark";
 
 export type BenchmarkProps = {
     network: FeatureCollection<LineString>,
@@ -23,8 +24,9 @@ export const registeredBenchmarks = (network: FeatureCollection<LineString>, pai
 
         // Others
         CreateTerraRouteCheapRulerBenchmark({ ...parameters, enabled: false }),
-        CreateTerraRouteFibonacciBenchmark({ ...parameters, enabled: false }),
-        CreateTerraRoutePairingBenchmark({ ...parameters, enabled: false }),
+        CreateTerraRouteFibonacciBenchmark({ ...parameters, enabled: true }),
+        CreateTerraRoutePairingBenchmark({ ...parameters, enabled: true }),
+        CreateTerraRouteMinHeapBenchmark({ ...parameters, enabled: true }),
         CreateTerraRouteCheapRulerBenchmark({ ...parameters, enabled: false }),
         CreateNgraphGraphBenchmark({ ...parameters, enabled: false }),
     ])

--- a/src/heap/four-ary-heap.spec.ts
+++ b/src/heap/four-ary-heap.spec.ts
@@ -1,0 +1,149 @@
+import { FourAryHeap } from "./four-ary-heap";
+
+describe("FourAryHeap", () => {
+    it("starts empty", () => {
+        const heap = new FourAryHeap();
+        expect(heap.size()).toBe(0);
+        expect(heap.extractMin()).toBeNull();
+    });
+
+    it("inserts and extracts a single element", () => {
+        const heap = new FourAryHeap();
+        heap.insert(5, 123);
+        expect(heap.size()).toBe(1);
+        expect(heap.extractMin()).toBe(123);
+        expect(heap.size()).toBe(0);
+        expect(heap.extractMin()).toBeNull();
+    });
+
+    it("extracts in ascending key order for ascending inserts", () => {
+        const heap = new FourAryHeap();
+        [1, 2, 3, 4, 5].forEach((k) => heap.insert(k, k + 100));
+
+        expect(heap.extractMin()).toBe(101);
+        expect(heap.extractMin()).toBe(102);
+        expect(heap.extractMin()).toBe(103);
+        expect(heap.extractMin()).toBe(104);
+        expect(heap.extractMin()).toBe(105);
+        expect(heap.extractMin()).toBeNull();
+    });
+
+    it("extracts in ascending key order for descending inserts", () => {
+        const heap = new FourAryHeap();
+        [5, 4, 3, 2, 1].forEach((k) => heap.insert(k, k + 200));
+
+        expect(heap.extractMin()).toBe(201);
+        expect(heap.extractMin()).toBe(202);
+        expect(heap.extractMin()).toBe(203);
+        expect(heap.extractMin()).toBe(204);
+        expect(heap.extractMin()).toBe(205);
+        expect(heap.extractMin()).toBeNull();
+    });
+
+    it("is stable for duplicate keys (FIFO among equals)", () => {
+        const heap = new FourAryHeap();
+        heap.insert(10, 1);
+        heap.insert(10, 2);
+        heap.insert(10, 3);
+        heap.insert(5, 99); // smaller key should come out first
+
+        expect(heap.extractMin()).toBe(99); // key 5
+        // Now all key=10, should preserve insertion order
+        expect(heap.extractMin()).toBe(1);
+        expect(heap.extractMin()).toBe(2);
+        expect(heap.extractMin()).toBe(3);
+        expect(heap.extractMin()).toBeNull();
+    });
+
+    it("handles a mix of negative and positive keys", () => {
+        const heap = new FourAryHeap();
+        const items = [
+            { key: -10, value: 1 },
+            { key: 0, value: 2 },
+            { key: 10, value: 3 },
+            { key: -5, value: 4 },
+            { key: 5, value: 5 },
+        ];
+        items.forEach((it) => heap.insert(it.key, it.value));
+
+        expect(heap.extractMin()).toBe(1); // -10
+        expect(heap.extractMin()).toBe(4); // -5
+        expect(heap.extractMin()).toBe(2); // 0
+        expect(heap.extractMin()).toBe(5); // 5
+        expect(heap.extractMin()).toBe(3); // 10
+        expect(heap.extractMin()).toBeNull();
+    });
+
+    it("updates size correctly across operations", () => {
+        const heap = new FourAryHeap();
+        expect(heap.size()).toBe(0);
+
+        heap.insert(2, 100);
+        heap.insert(1, 200);
+        heap.insert(3, 300);
+        expect(heap.size()).toBe(3);
+
+        expect(heap.extractMin()).toBe(200); // key 1
+        expect(heap.size()).toBe(2);
+
+        expect(heap.extractMin()).toBe(100); // key 2
+        expect(heap.size()).toBe(1);
+
+        expect(heap.extractMin()).toBe(300); // key 3
+        expect(heap.size()).toBe(0);
+
+        expect(heap.extractMin()).toBeNull();
+        expect(heap.size()).toBe(0);
+    });
+
+    it("maintains stability with interleaved inserts for equal keys", () => {
+        const heap = new FourAryHeap();
+        // Insert several equal keys, then interleave more later
+        heap.insert(2, 1); // 1st with key=2
+        heap.insert(2, 2); // 2nd with key=2
+        heap.insert(1, 9); // smallest
+        heap.insert(3, 8);
+        heap.insert(2, 3); // 3rd with key=2
+        heap.insert(2, 4); // 4th with key=2
+
+        // Smallest key first
+        expect(heap.extractMin()).toBe(9); // key=1
+        // Now all remaining mins are key=2; order should be FIFO among them
+        expect(heap.extractMin()).toBe(1);
+        expect(heap.extractMin()).toBe(2);
+        expect(heap.extractMin()).toBe(3);
+        expect(heap.extractMin()).toBe(4);
+        expect(heap.extractMin()).toBe(8); // key=3
+        expect(heap.extractMin()).toBeNull();
+    });
+
+    it("produces sorted and stable output for a random workload", () => {
+        const heap = new FourAryHeap();
+        const items: { key: number; value: number; idx: number }[] = [];
+
+        const count = 5000;
+        const keyRange = 100; // many duplicates to stress stability
+        for (let i = 0; i < count; i += 1) {
+            const key = Math.floor(Math.random() * keyRange) - Math.floor(keyRange / 2);
+            const value = i; // use insertion index as value to check stability among equals
+            items.push({ key, value, idx: i });
+            heap.insert(key, value);
+        }
+
+        // Compute expected order: by key asc, then original index asc (stable)
+        const expectedValues = items
+            .slice()
+            .sort((a, b) => (a.key === b.key ? a.idx - b.idx : a.key - b.key))
+            .map((x) => x.value);
+
+        const extracted: number[] = [];
+        let v: number | null;
+        do {
+            v = heap.extractMin();
+            if (v !== null) extracted.push(v);
+        } while (v !== null);
+
+        expect(extracted).toEqual(expectedValues);
+        expect(heap.size()).toBe(0);
+    });
+});

--- a/src/heap/four-ary-heap.ts
+++ b/src/heap/four-ary-heap.ts
@@ -1,0 +1,143 @@
+import { Heap } from "./heap";
+
+interface Node {
+    key: number;
+    value: number;
+    index: number; // insertion order for stable tie-breaking
+}
+
+/**
+ * A 4-ary min-heap with stable tie-breaking on insertion order.
+ * Parent(i) = floor((i - 1) / 4)
+ * Children(i) = 4*i + 1 .. 4*i + 4
+ */
+export class FourAryHeap implements Heap {
+    // Parallel arrays for fewer object allocations and faster property access
+    private keys: number[] = [];
+    private values: number[] = [];
+    private idxs: number[] = [];
+    private length = 0; // number of valid elements
+    private insertCounter = 0;
+
+    insert(key: number, value: number): void {
+        // Bubble-up using local variables (avoid temporary node object)
+        let i = this.length;
+        this.length = i + 1;
+
+        let ck = key;
+        let cv = value;
+        let ci = this.insertCounter++;
+
+        while (i > 0) {
+            const p = (i - 1) >>> 2; // divide by 4
+            const pk = this.keys[p];
+            const pi = this.idxs[p];
+            if (ck > pk || (ck === pk && ci > pi)) break;
+
+            // move parent down
+            this.keys[i] = pk;
+            this.values[i] = this.values[p];
+            this.idxs[i] = pi;
+            i = p;
+        }
+
+        // place the new node
+        this.keys[i] = ck;
+        this.values[i] = cv;
+        this.idxs[i] = ci;
+    }
+
+    extractMin(): number | null {
+        const n = this.length;
+        if (n === 0) return null;
+
+        const minValue = this.values[0];
+        const last = n - 1;
+        this.length = last;
+
+        if (last > 0) {
+            // Move last element to root then bubble down
+            this.keys[0] = this.keys[last];
+            this.values[0] = this.values[last];
+            this.idxs[0] = this.idxs[last];
+            this.bubbleDown(0);
+        }
+
+        return minValue;
+    }
+
+    size(): number {
+        return this.length;
+    }
+
+    private bubbleDown(i: number): void {
+        const n = this.length;
+        const k = this.keys;
+        const v = this.values;
+        const idx = this.idxs;
+
+        const nodeK = k[i];
+        const nodeV = v[i];
+        const nodeI = idx[i];
+
+        while (true) {
+            const c1 = (i << 2) + 1; // 4*i + 1
+            if (c1 >= n) break; // no children
+
+            // find smallest among up to 4 children
+            let smallest = c1;
+            let sK = k[c1];
+            let sI = idx[c1];
+            let sV = v[c1];
+
+            const c2 = c1 + 1;
+            if (c2 < n) {
+                const k2 = k[c2];
+                const i2 = idx[c2];
+                if (k2 < sK || (k2 === sK && i2 < sI)) {
+                    smallest = c2;
+                    sK = k2;
+                    sI = i2;
+                    sV = v[c2];
+                }
+            }
+
+            const c3 = c1 + 2;
+            if (c3 < n) {
+                const k3 = k[c3];
+                const i3 = idx[c3];
+                if (k3 < sK || (k3 === sK && i3 < sI)) {
+                    smallest = c3;
+                    sK = k3;
+                    sI = i3;
+                    sV = v[c3];
+                }
+            }
+
+            const c4 = c1 + 3;
+            if (c4 < n) {
+                const k4 = k[c4];
+                const i4 = idx[c4];
+                if (k4 < sK || (k4 === sK && i4 < sI)) {
+                    smallest = c4;
+                    sK = k4;
+                    sI = i4;
+                    sV = v[c4];
+                }
+            }
+
+            if (sK < nodeK || (sK === nodeK && sI < nodeI)) {
+                k[i] = sK;
+                v[i] = sV;
+                idx[i] = sI;
+                i = smallest;
+            } else {
+                break;
+            }
+        }
+
+        k[i] = nodeK;
+        v[i] = nodeV;
+        idx[i] = nodeI;
+    }
+}

--- a/src/terra-route.ts
+++ b/src/terra-route.ts
@@ -4,6 +4,7 @@ import { createCheapRuler } from "./distance/cheap-ruler"; // Factory for faster
 import { MinHeap } from "./heap/min-heap"; // Default binary heap for A*
 import { HeapConstructor } from "./heap/heap"; // Heap interface so users can plug custom heaps
 import { LineStringGraph } from "./graph/graph"; // Exported type (not used internally here)
+import { FourAryHeap } from "./heap/four-ary-heap";
 
 interface Router { // Contract for a router implementation
     buildRouteGraph(network: FeatureCollection<LineString>): void; // Build internal graph from GeoJSON LineStrings
@@ -39,7 +40,7 @@ class TerraRoute implements Router { // Main router class implementing A*
         heap?: HeapConstructor; // Optional heap implementation override
     }) {
         this.distanceMeasurement = options?.distanceMeasurement ?? haversineDistance; // Default to haversine
-        this.heapConstructor = options?.heap ?? MinHeap; // Default to MinHeap
+        this.heapConstructor = options?.heap ?? FourAryHeap; // Default to MinHeap
     }
 
     /**

--- a/src/terra-route.ts
+++ b/src/terra-route.ts
@@ -163,8 +163,14 @@ class TerraRoute implements Router { // Main router class implementing A*
     }
 
     /**
-     * Computes the shortest route between two points using A*.
-     */
+      * Computes the shortest route between two points in the network using the A* algorithm.
+      * 
+      * @param start - A GeoJSON Point Feature representing the start location.
+      * @param end - A GeoJSON Point Feature representing the end location.
+      * @returns A GeoJSON LineString Feature representing the shortest path, or null if no path is found.
+      * 
+      * @throws Error if the network has not been built yet with buildRouteGraph(network).
+      */
     public getRoute(
         start: Feature<Point>, // Start point feature
         end: Feature<Point> // End point feature
@@ -331,4 +337,4 @@ class TerraRoute implements Router { // Main router class implementing A*
     }
 }
 
-export { TerraRoute, createCheapRuler, haversineDistance, LineStringGraph } // Export public API
+export { TerraRoute, createCheapRuler, haversineDistance, LineStringGraph }  


### PR DESCRIPTION
## Description of Changes

Introduces significant performance improvements compared to `main` going from ~x2.25 faster to ~x3.1 faster than geojson-path-finder

Uses some exotic data structures to achieve these, namely four-ary heap and Compress Sparse Row.

Four-ary heap:

A 4-ary heap is a special tree structure where each parent can have up to four children instead of two, like in a binary heap. It is kept complete, meaning all levels are filled from left to right, and it follows the heap property: in a min-heap, every parent is smaller than its children, and in a max-heap, every parent is larger. This design makes the tree shorter than a binary heap, which can speed up some operations, though each step involves checking more children.

CSR:

A Compressed Sparse Row (CSR) format is a way to store large, sparse matrices efficiently by only keeping track of the nonzero values. Instead of storing every element, it uses three arrays: one for the nonzero values themselves, one for the column indices of those values, and one that marks where each row starts and ends.  

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 