### PR TITLE
perf: 15 percent perf improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ npm run benchmark
 Here is an example output of a benchmark run for routing:
 
 <pre>
-Terra Route         | █████ 142ms
-GeoJSON Path Finder | ██████████████████ 570ms
-ngraph.graph        | ██████████████████████████████████████████████████ 1570ms
+Terra Route         | ████ 91ms
+GeoJSON Path Finder | ██████████████████████ 537ms
+ngraph.graph        | ██████████████████████████████████████████████████ 1229ms
 </pre>
 
-Using default Haversine distance, Terra Route is approximately 4.6x faster than GeoJSON Path Finder with Haversine distance for A -> B path finding. If you pass in the CheapRuler distance metric (you can use the exposed `createCheapRuler` function), it is approximately x8 faster than GeoJSON Path Finder with Haversine distance. 
+Using default Haversine distance, Terra Route is approximately 5.75x faster than GeoJSON Path Finder with Haversine distance for A -> B path finding. If you pass in the CheapRuler distance metric (you can use the exposed `createCheapRuler` function), it is approximately x8 faster than GeoJSON Path Finder with Haversine distance. 
 
 For initialisation of the network, Terra Route is approximately 19x faster with Haversine than GeoJSON Path Finder. Terra Draw splits out instantiating the Class of the library from the actual graph building, which is done via `buildRouteGraph`. This allows you to defer graph creation to an appropriate time.
 

--- a/src/terra-route.spec.ts
+++ b/src/terra-route.spec.ts
@@ -560,7 +560,7 @@ describe("TerraRoute", () => {
             const isLowerBranch = JSON.stringify(firstRoute) === JSON.stringify(lowerBranch);
             expect(isUpperBranch || isLowerBranch).toBe(true);
 
-            for (let i = 0; i < 50; i++) {
+            for (let i = 0; i < 256; i++) {
                 const next = routeFinder.getRoute(start, end);
                 expect(next).not.toBeNull();
                 expect(next!.geometry.coordinates).toEqual(firstRoute);

--- a/src/terra-route.spec.ts
+++ b/src/terra-route.spec.ts
@@ -522,6 +522,239 @@ describe("TerraRoute", () => {
             expect(result!.geometry.coordinates.length).toBeGreaterThanOrEqual(2);
         });
 
+        it("returns a stable route across repeated calls when multiple equal-length routes exist", () => {
+            const network = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [1, 1],
+                    [2, 0],
+                ]),
+                createLineStringFeature([
+                    [0, 0],
+                    [1, -1],
+                    [2, 0],
+                ]),
+            ]);
+
+            routeFinder.buildRouteGraph(network);
+
+            const start = createPointFeature([0, 0]);
+            const end = createPointFeature([2, 0]);
+
+            const first = routeFinder.getRoute(start, end);
+            expect(first).not.toBeNull();
+
+            const upperBranch = [
+                [0, 0],
+                [1, 1],
+                [2, 0],
+            ];
+            const lowerBranch = [
+                [0, 0],
+                [1, -1],
+                [2, 0],
+            ];
+
+            const firstRoute = first!.geometry.coordinates;
+            const isUpperBranch = JSON.stringify(firstRoute) === JSON.stringify(upperBranch);
+            const isLowerBranch = JSON.stringify(firstRoute) === JSON.stringify(lowerBranch);
+            expect(isUpperBranch || isLowerBranch).toBe(true);
+
+            for (let i = 0; i < 50; i++) {
+                const next = routeFinder.getRoute(start, end);
+                expect(next).not.toBeNull();
+                expect(next!.geometry.coordinates).toEqual(firstRoute);
+            }
+        });
+
+        it("returns a stable route across repeated calls in a larger graph with multiple equal-length alternatives", () => {
+            const network = createFeatureCollection([
+                // Baseline corridor (equal in total length to the two detours below)
+                createLineStringFeature([
+                    [0, 0],
+                    [1, 0],
+                    [2, 0],
+                    [3, 0],
+                    [4, 0],
+                ]),
+
+                // Upper detour: four diagonals, same total distance as baseline corridor
+                createLineStringFeature([
+                    [0, 0],
+                    [1, 1],
+                    [2, 0],
+                    [3, 1],
+                    [4, 0],
+                ]),
+
+                // Lower detour: mirrored version of upper detour, also same total distance
+                createLineStringFeature([
+                    [0, 0],
+                    [1, -1],
+                    [2, 0],
+                    [3, -1],
+                    [4, 0],
+                ]),
+
+                // Extra branches that should not change shortest-path cost to the destination
+                createLineStringFeature([
+                    [1, 0],
+                    [1, 2],
+                ]),
+                createLineStringFeature([
+                    [2, 0],
+                    [2, 2],
+                ]),
+                createLineStringFeature([
+                    [3, 0],
+                    [3, 2],
+                ]),
+                createLineStringFeature([
+                    [1, 0],
+                    [1, -2],
+                ]),
+                createLineStringFeature([
+                    [2, 0],
+                    [2, -2],
+                ]),
+                createLineStringFeature([
+                    [3, 0],
+                    [3, -2],
+                ]),
+            ]);
+
+            routeFinder.buildRouteGraph(network);
+
+            const start = createPointFeature([0, 0]);
+            const end = createPointFeature([4, 0]);
+
+            const first = routeFinder.getRoute(start, end);
+            expect(first).not.toBeNull();
+
+            const baseline = [
+                [0, 0],
+                [1, 0],
+                [2, 0],
+                [3, 0],
+                [4, 0],
+            ];
+            const upper = [
+                [0, 0],
+                [1, 1],
+                [2, 0],
+                [3, 1],
+                [4, 0],
+            ];
+            const lower = [
+                [0, 0],
+                [1, -1],
+                [2, 0],
+                [3, -1],
+                [4, 0],
+            ];
+
+            const firstRoute = first!.geometry.coordinates;
+            const isBaseline = JSON.stringify(firstRoute) === JSON.stringify(baseline);
+            const isUpper = JSON.stringify(firstRoute) === JSON.stringify(upper);
+            const isLower = JSON.stringify(firstRoute) === JSON.stringify(lower);
+            expect(isBaseline || isUpper || isLower).toBe(true);
+
+            for (let i = 0; i < 100; i++) {
+                const next = routeFinder.getRoute(start, end);
+                expect(next).not.toBeNull();
+                expect(next!.geometry.coordinates).toEqual(firstRoute);
+            }
+        });
+
+        it("keeps the selected equal-length route stable after landmark heuristic activates", () => {
+            const network = createFeatureCollection([
+                createLineStringFeature([
+                    [0, 0],
+                    [1, 1],
+                    [2, 0],
+                ]),
+                createLineStringFeature([
+                    [0, 0],
+                    [1, -1],
+                    [2, 0],
+                ]),
+            ]);
+
+            routeFinder.buildRouteGraph(network);
+
+            const start = createPointFeature([0, 0]);
+            const end = createPointFeature([2, 0]);
+
+            const first = routeFinder.getRoute(start, end);
+            expect(first).not.toBeNull();
+
+            // Cross the landmark activation threshold and ensure output remains stable.
+            for (let i = 0; i < 300; i++) {
+                const next = routeFinder.getRoute(start, end);
+                expect(next).not.toBeNull();
+            }
+
+            const afterThreshold = routeFinder.getRoute(start, end);
+            expect(afterThreshold).not.toBeNull();
+            expect(afterThreshold!.geometry.coordinates).toEqual(first!.geometry.coordinates);
+        });
+
+        it("still returns the unique shortest path after crossing landmark activation threshold", () => {
+            const expectedCorridor = [
+                [0, 0],
+                [1, 0],
+                [2, 0],
+                [3, 0],
+                [4, 0],
+                [5, 0],
+            ];
+
+            const network = createFeatureCollection([
+                createLineStringFeature(expectedCorridor),
+
+                // Distractor branches should not affect shortest-path choice.
+                createLineStringFeature([
+                    [1, 0],
+                    [1, 1],
+                ]),
+                createLineStringFeature([
+                    [2, 0],
+                    [2, 1],
+                ]),
+                createLineStringFeature([
+                    [3, 0],
+                    [3, 1],
+                ]),
+                createLineStringFeature([
+                    [2, 0],
+                    [2, -1],
+                ]),
+                createLineStringFeature([
+                    [3, 0],
+                    [3, -1],
+                ]),
+            ]);
+
+            routeFinder.buildRouteGraph(network);
+
+            const start = createPointFeature([0, 0]);
+            const end = createPointFeature([5, 0]);
+
+            const beforeThreshold = routeFinder.getRoute(start, end);
+            expect(beforeThreshold).not.toBeNull();
+            expect(beforeThreshold!.geometry.coordinates).toEqual(expectedCorridor);
+
+            // Trigger landmark table build and continue routing beyond threshold.
+            for (let i = 0; i < 300; i++) {
+                const next = routeFinder.getRoute(start, end);
+                expect(next).not.toBeNull();
+            }
+
+            const afterThreshold = routeFinder.getRoute(start, end);
+            expect(afterThreshold).not.toBeNull();
+            expect(afterThreshold!.geometry.coordinates).toEqual(expectedCorridor);
+        });
+
         it("supports a custom heap implementation", () => {
             // Minimal heap that satisfies the expected interface (extracts minimum key).
             class SimpleMinHeap {

--- a/src/terra-route.ts
+++ b/src/terra-route.ts
@@ -31,12 +31,15 @@ class TerraRoute implements Router {
     private landmarkCount = 0;
     private landmarkDistancesFlat: Float64Array | null = null; // Layout: [landmark0 distances..., landmark1 distances...]
     private readonly maxLandmarks = 4;
+    private readonly landmarkActivationThreshold = 256;
+    private routeQueriesSinceLandmarkInvalidation = 0;
     private landmarksDirty = true;
 
     // Reusable typed scratch buffers for shortest-path search
     private gScoreScratch: Float64Array | null = null; // gScore per node (cost from start)
+    private gScoreStampScratch: Uint32Array | null = null; // Query stamp for gScore validity
     private cameFromScratch: Int32Array | null = null; // Predecessor per node for path reconstruction
-    private visitedScratch: Uint8Array | null = null; // Visited set to avoid reprocessing
+    private visitedScratch: Uint32Array | null = null; // Query stamp for visited nodes
     private heuristicScratch: Float64Array | null = null; // Cached h(node) per query for A*
     private heuristicStampScratch: Uint32Array | null = null; // Query-stamp per node for heuristic cache validity
     private heuristicQueryStamp = 1; // Monotonic stamp to avoid clearing heuristic cache each query
@@ -73,6 +76,7 @@ class TerraRoute implements Router {
         this.landmarkNodeCount = 0;
         this.landmarkCount = 0;
         this.landmarkDistancesFlat = null;
+        this.routeQueriesSinceLandmarkInvalidation = 0;
         this.landmarksDirty = true;
 
         // Hoist to locals for speed (avoid repeated property lookups in hot loops)
@@ -256,6 +260,7 @@ class TerraRoute implements Router {
         this.landmarkNodeCount = 0;
         this.landmarkCount = 0;
         this.landmarkDistancesFlat = null;
+        this.routeQueriesSinceLandmarkInvalidation = 0;
 
         // Keep adjacency list for *future* dynamic additions, but clear existing edges to avoid duplication.
         this.adjacencyList = new Array(nodeCount);
@@ -310,19 +315,18 @@ class TerraRoute implements Router {
 
         // Non-null after ensure
         const gF = this.gScoreScratch!; // gScore from start
+        const gScoreStamp = this.gScoreStampScratch!;
         const prevF = this.cameFromScratch!; // predecessor for reconstruction
         const visF = this.visitedScratch!;
         const heuristic = this.heuristicScratch!;
         const heuristicStamp = this.heuristicStampScratch!;
 
-        gF.fill(PositiveInfinity, 0, nodeCount);
-        prevF.fill(-1, 0, nodeCount);
-        visF.fill(0, 0, nodeCount);
-
-        // Increment query stamp for heuristic cache validity; handle wraparound.
+        // Increment query stamp for all query-local scratch state; handle wraparound.
         let queryStamp = (this.heuristicQueryStamp + 1) >>> 0;
         if (queryStamp === 0) {
             heuristicStamp.fill(0, 0, nodeCount);
+            gScoreStamp.fill(0, 0, nodeCount);
+            visF.fill(0, 0, nodeCount);
             queryStamp = 1;
         }
         this.heuristicQueryStamp = queryStamp;
@@ -369,6 +373,7 @@ class TerraRoute implements Router {
         }
 
         gF[startIndex] = 0;
+    gScoreStamp[startIndex] = queryStamp;
         openF2.insert(getHeuristic(startIndex), startIndex);
 
         while (openF2.size() > 0) {
@@ -376,14 +381,14 @@ class TerraRoute implements Router {
             if (current === null) {
                 break;
             }
-            if (visF[current] !== 0) {
+            if (visF[current] === queryStamp) {
                 continue;
             }
             if (current === endIndex) {
                 break;
             }
 
-            visF[current] = 1;
+            visF[current] = queryStamp;
             const currentDistance = gF[current];
 
             const isCsrNode = hasCsr && current < csrNodeCount;
@@ -397,11 +402,15 @@ class TerraRoute implements Router {
                     const nb = neighbors[i];
                     const nbNode = nb.node;
                     const tentativeG = currentDistance + nb.distance;
-                    if (tentativeG >= gF[nbNode]) {
+                    const bestKnownG = gScoreStamp[nbNode] === queryStamp
+                        ? gF[nbNode]
+                        : PositiveInfinity;
+                    if (tentativeG >= bestKnownG) {
                         continue;
                     }
 
                     gF[nbNode] = tentativeG;
+                    gScoreStamp[nbNode] = queryStamp;
                     prevF[nbNode] = current;
                     openF2.insert(tentativeG + getHeuristic(nbNode), nbNode);
                 }
@@ -411,17 +420,21 @@ class TerraRoute implements Router {
             for (let i = csrOffsets![current], endOff = csrOffsets![current + 1]; i < endOff; i++) {
                 const nbNode = csrIndices![i];
                 const tentativeG = currentDistance + csrDistances![i];
-                if (tentativeG >= gF[nbNode]) {
+                const bestKnownG = gScoreStamp[nbNode] === queryStamp
+                    ? gF[nbNode]
+                    : PositiveInfinity;
+                if (tentativeG >= bestKnownG) {
                     continue;
                 }
 
                 gF[nbNode] = tentativeG;
+                gScoreStamp[nbNode] = queryStamp;
                 prevF[nbNode] = current;
                 openF2.insert(tentativeG + getHeuristic(nbNode), nbNode);
             }
         }
 
-        if (gF[endIndex] === PositiveInfinity) {
+        if (gScoreStamp[endIndex] !== queryStamp) {
             return null;
         }
 
@@ -510,6 +523,12 @@ class TerraRoute implements Router {
         if (!this.landmarksDirty) {
             return;
         }
+
+        this.routeQueriesSinceLandmarkInvalidation++;
+        if (this.routeQueriesSinceLandmarkInvalidation < this.landmarkActivationThreshold) {
+            return;
+        }
+
         this.buildLandmarkHeuristicData();
     }
 
@@ -606,6 +625,7 @@ class TerraRoute implements Router {
     private ensureScratch(size: number): void {
         const ifAlreadyBigEnough = this.scratchCapacity >= size
             && this.gScoreScratch
+            && this.gScoreStampScratch
             && this.cameFromScratch
             && this.visitedScratch
             && this.heuristicScratch
@@ -616,8 +636,9 @@ class TerraRoute implements Router {
         }
         const capacity = size | 0; // Ensure integer
         this.gScoreScratch = new Float64Array(capacity);
+        this.gScoreStampScratch = new Uint32Array(capacity);
         this.cameFromScratch = new Int32Array(capacity);
-        this.visitedScratch = new Uint8Array(capacity);
+        this.visitedScratch = new Uint32Array(capacity);
         this.heuristicScratch = new Float64Array(capacity);
         this.heuristicStampScratch = new Uint32Array(capacity);
         this.scratchCapacity = capacity;

--- a/src/terra-route.ts
+++ b/src/terra-route.ts
@@ -37,11 +37,11 @@ class TerraRoute implements Router {
 
     // Reusable typed scratch buffers for shortest-path search
     private gScoreScratch: Float64Array | null = null; // gScore per node (cost from start)
-    private gScoreStampScratch: Uint32Array | null = null; // Query stamp for gScore validity
+    private gScoreStampScratch: Uint8Array | null = null; // Query stamp for gScore validity
     private cameFromScratch: Int32Array | null = null; // Predecessor per node for path reconstruction
-    private visitedScratch: Uint32Array | null = null; // Query stamp for visited nodes
+    private visitedScratch: Uint8Array | null = null; // Query stamp for visited nodes
     private heuristicScratch: Float64Array | null = null; // Cached h(node) per query for A*
-    private heuristicStampScratch: Uint32Array | null = null; // Query-stamp per node for heuristic cache validity
+    private heuristicStampScratch: Uint8Array | null = null; // Query-stamp per node for heuristic cache validity
     private heuristicQueryStamp = 1; // Monotonic stamp to avoid clearing heuristic cache each query
     private scratchCapacity = 0; // Current capacity of scratch arrays
 
@@ -322,8 +322,8 @@ class TerraRoute implements Router {
         const heuristicStamp = this.heuristicStampScratch!;
 
         // Increment query stamp for all query-local scratch state; handle wraparound.
-        let queryStamp = (this.heuristicQueryStamp + 1) >>> 0;
-        if (queryStamp === 0) {
+        let queryStamp = this.heuristicQueryStamp + 1;
+        if (queryStamp > 255) {
             heuristicStamp.fill(0, 0, nodeCount);
             gScoreStamp.fill(0, 0, nodeCount);
             visF.fill(0, 0, nodeCount);
@@ -636,11 +636,11 @@ class TerraRoute implements Router {
         }
         const capacity = size | 0; // Ensure integer
         this.gScoreScratch = new Float64Array(capacity);
-        this.gScoreStampScratch = new Uint32Array(capacity);
+        this.gScoreStampScratch = new Uint8Array(capacity);
         this.cameFromScratch = new Int32Array(capacity);
-        this.visitedScratch = new Uint32Array(capacity);
+        this.visitedScratch = new Uint8Array(capacity);
         this.heuristicScratch = new Float64Array(capacity);
-        this.heuristicStampScratch = new Uint32Array(capacity);
+        this.heuristicStampScratch = new Uint8Array(capacity);
         this.scratchCapacity = capacity;
     }
 


### PR DESCRIPTION
## Description of Changes

- Adds tests for route stability 
- Replaced per-query full scratch-buffer resets with query stamps
- Deferred four-landmark preprocessing until 256 route queries
- Performance is about 15% faster

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 